### PR TITLE
Consolidate Dockerfile apt commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM ubuntu:16.04
 LABEL maintainer="Michael Lynch <michael@mtlynch.io>"
 
-RUN apt-get update --yes
-RUN apt-get upgrade --yes
-RUN apt-get install --yes \
-      build-essential
+RUN apt-get update --yes && \
+    apt-get upgrade --yes && \
+    apt-get install --yes \
+    build-essential && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -Rf /usr/share/doc && \
+    rm -Rf /usr/share/man && \
+    apt-get autoremove -y
 
 ADD . /crfpp
 WORKDIR /crfpp
@@ -13,10 +17,3 @@ RUN ./configure && \
     make && \
     make install && \
     ldconfig
-
-# Clean up.
-RUN rm -rf /var/lib/apt/lists/* && \
-    rm -Rf /usr/share/doc && \
-    rm -Rf /usr/share/man && \
-    apt-get autoremove -y && \
-    apt-get clean


### PR DESCRIPTION
# Summary

1. update and install commands should be on the same line, per [official docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)
> Always combine RUN apt-get update with apt-get install in the same RUN statement.
2. cleanup should be in the same layer as install to reduce docker layer size. See discussion [here](https://github.com/waleedka/modern-deep-learning-docker/issues/4)
3. apt-get clean is redundant on images derived from Ubuntu base image. Same reference as 1)
> Official Debian and Ubuntu images automatically run apt-get clean, so explicit invocation is not required.