### PR TITLE
Updates the Dockerfile to target Ubuntu 20.04 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 LABEL maintainer="Michael Lynch <michael@mtlynch.io>"
 
 RUN apt-get update --yes && \


### PR DESCRIPTION
Updates the Dockerfile to target Ubuntu 20.04 (LTS). I've tested that the it indeed builds and runs happily.